### PR TITLE
Fix DB2 SAVEPOINT syntax to include required ON ROLLBACK RETAIN CURSOR

### DIFF
--- a/source/db2SetSavepoint.c
+++ b/source/db2SetSavepoint.c
@@ -28,10 +28,10 @@ void db2SetSavepoint (DB2Session* session, int nest_level) {
   db2Debug1("> db2SetSavepoint(session, nest_level %d)",nest_level);
   db2Debug2("  xact_level: %d",session->connp->xact_level);
   while (session->connp->xact_level < nest_level) {
-    SQLCHAR query[40];
+    SQLCHAR query[80];
 
     db2Debug2("  db2_fdw::db2SetSavepoint: set savepoint s%d", session->connp->xact_level + 1);
-    snprintf((char*)query, 39, "SAVEPOINT s%d", session->connp->xact_level + 1);
+    snprintf((char*)query, 79, "SAVEPOINT s%d ON ROLLBACK RETAIN CURSORS", session->connp->xact_level + 1);
     db2Debug2("  query: '%s'",query);
 
     /* create statement handle */


### PR DESCRIPTION
I had the following error while executing a Postgresql procedure querying foreign tables to insert data.
In the procedure if an error occurs it should raise exception to be handled correctly.
Here is the procedure (simplified, for comprehension):
```
CREATE OR REPLACE PROCEDURE pgschema.pr_test(
    IN p_id VARCHAR(8)
)
LANGUAGE plpgsql
AS $$
DECLARE
    v_error_message VARCHAR(500);
    v_next_id INTEGER;
BEGIN
    BEGIN
        -- Reading from foreign tables to insert data to pg local tables
	-- SQL code removed
        RAISE NOTICE 'Synchronization completed successfully for ID: %', p_id;
    EXCEPTION WHEN OTHERS THEN
        -- Log the error
        GET STACKED DIAGNOSTICS v_error_message = MESSAGE_TEXT;
        -- SQL code removed
        RAISE NOTICE 'Error for ID %: %', p_id, v_error_message;
        RAISE;
    END;
END;
$$;
```

Here is the following error i got while executing the procedure :
> SQL Error [HV00L]: ERROR: error setting savepoint: SQLExecute failed to set savepoint Détail : SQLSTATE = 42601 SQLCODE = -104 line=49 file=source/db2SetSavepoint.c [IBM][CLI Driver][DB2/LINUXX8664] SQL0104N An unexpected token "END-OF-STATEMENT" was found following "SAVEPOINT S2". Expected tokens may include: "on rollback retain cursors". SQLSTATE=4260

Asked Claude AI to fix.
I tested it and it works fine.

Here is Claude AI analysis:
DB2 requires the full syntax for savepoints:
  SAVEPOINT name ON ROLLBACK RETAIN CURSORS

The previous code was only sending:
  SAVEPOINT name

This caused DB2 to reject the statement with error:
  SQL0104N An unexpected token "END-OF-STATEMENT" was found following "SAVEPOINT Sn".
  Expected tokens may include: "on rollback retain cursors"

This error occurred when PostgreSQL PL/pgSQL procedures with EXCEPTION blocks tried to use foreign tables, as PostgreSQL uses subtransactions (savepoints) to implement exception handling.

Changes:
- Updated query buffer size from 40 to 80 bytes to accommodate longer syntax
- Changed SAVEPOINT statement to include ON ROLLBACK RETAIN CURSORS clause

Fixes error when using foreign tables in PL/pgSQL procedures with exception handling.