### PR TITLE
Fix segmentation fault when using JWT authentication without user

### DIFF
--- a/source/db2AllocConnHdl.c
+++ b/source/db2AllocConnHdl.c
@@ -131,7 +131,10 @@ DB2ConnEntry* findconnEntry(DB2ConnEntry* start, const char* srvname, const char
   DB2ConnEntry* step = NULL;
   db2Debug2("  > findconnEntry");
   for (step = start; step != NULL; step = step->right){
-    if (strcmp(step->srvname, srvname) == 0 && strcmp(step->uid, user) == 0) {
+    /* NULL-safe comparison for JWT auth where user may be NULL */
+    int srv_match = (step->srvname && srvname) ? strcmp(step->srvname, srvname) == 0 : step->srvname == srvname;
+    int uid_match = (step->uid && user) ? strcmp(step->uid, user) == 0 : step->uid == user;
+    if (srv_match && uid_match) {
       break;
     }
   }


### PR DESCRIPTION
When using JWT token authentication via `CREATE USER MAPPING ... OPTIONS (jwt_token '...')` without specifying a user, the `findconnEntry()` function crashes with a segmentation fault.

**Affected file:** `source/db2AllocConnHdl.c`, Line 122-125

**Current code (broken):**
```c
for (step = start; step != NULL; step = step->right){
  if (strcmp(step->srvname, srvname) == 0 && strcmp(step->uid, user) == 0) {
    break;
  }
}
```

**Root cause:**

The function `findconnEntry()` uses `strcmp()` to compare `step->uid` with `user`, but when JWT authentication is used, `user` is `NULL`. Calling `strcmp()` with a `NULL` pointer causes undefined behavior (segmentation fault).

**Symptom:**

- `IMPORT FOREIGN SCHEMA` fails on first attempt with I/O error / backend crash
- Second attempt sometimes succeeds (connection handle partially cached)
- Only occurs with JWT authentication, password authentication works fine

**Fix:**

Replace the comparison in `source/db2AllocConnHdl.c` (Line 122-125) with NULL-safe string comparison:

```c
for (step = start; step != NULL; step = step->right){
  /* NULL-safe comparison for JWT auth where user may be NULL */
  int srv_match = (step->srvname && srvname) ? strcmp(step->srvname, srvname) == 0 : step->srvname == srvname;
  int uid_match = (step->uid && user) ? strcmp(step->uid, user) == 0 : step->uid == user;
  if (srv_match && uid_match) {
    break;
  }
}
```

**Testing:**

Tested with:
```sql
CREATE SERVER db2_server FOREIGN DATA WRAPPER db2_fdw OPTIONS (dbserver 'MYDB');
CREATE USER MAPPING FOR postgres SERVER db2_server OPTIONS (jwt_token 'eyJhbGciO...');
IMPORT FOREIGN SCHEMA "MYSCHEMA" FROM SERVER db2_server INTO public;
```

Before fix: Segfault on first attempt
After fix: Works reliably on first attempt